### PR TITLE
Handle file metadata in the correct bundle

### DIFF
--- a/src/EventListener/FileMetadataListener.php
+++ b/src/EventListener/FileMetadataListener.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2015 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\NewsBundle\EventListener;
+
+use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+use Contao\Database;
+use Contao\Database\Result;
+
+class FileMetadataListener
+{
+    /**
+     * @var ContaoFrameworkInterface
+     */
+    private $framework;
+
+    /**
+     * Constructor.
+     *
+     * @param ContaoFrameworkInterface $framework
+     */
+    public function __construct(ContaoFrameworkInterface $framework)
+    {
+        $this->framework = $framework;
+    }
+
+    /**
+     * Adds meta data information to the current request.
+     *
+     * @param string $ptable The parent table name
+     * @param int    $pid    The parent ID name
+     *
+     * @return Result|false
+     */
+    public function onAddFileMetaInformationToRequest($ptable, $pid)
+    {
+        switch ($ptable) {
+            case 'tl_news':
+                return $this
+                    ->getDatabase()
+                    ->prepare("SELECT * FROM tl_page WHERE id=(SELECT jumpTo FROM tl_news_archive WHERE id=(SELECT pid FROM tl_news WHERE id=?))")
+                    ->execute($pid)
+                ;
+
+            case 'tl_news_archive':
+                return $this
+                    ->getDatabase()
+                    ->prepare("SELECT * FROM tl_page WHERE id=(SELECT jumpTo FROM tl_news_archive WHERE id=?)")
+                    ->execute($pid)
+                ;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns the database instance.
+     *
+     * @return Database
+     */
+    private function getDatabase()
+    {
+        $this->framework->initialize();
+
+        return $this->framework->getAdapter('Contao\Database')->getInstance();
+    }
+}

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -1,4 +1,9 @@
 services:
+    contao_news.listener.file_metadata:
+         class: Contao\NewsBundle\EventListener\FileMetadataListener
+         arguments:
+            - "@contao.framework"
+
     contao_news.listener.preview_url_create:
         class: Contao\NewsBundle\EventListener\PreviewUrlCreateListener
         arguments:

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -51,6 +51,7 @@ $GLOBALS['TL_CRON']['daily'][] = array('News', 'generateFeeds');
 $GLOBALS['TL_HOOKS']['removeOldFeeds'][] = array('News', 'purgeOldFeeds');
 $GLOBALS['TL_HOOKS']['getSearchablePages'][] = array('News', 'getSearchablePages');
 $GLOBALS['TL_HOOKS']['generateXmlFiles'][] = array('News', 'generateFeeds');
+$GLOBALS['TL_HOOKS']['addFileMetaInformationToRequest'][] = array('contao_news.listener.file_metadata', 'onAddFileMetaInformationToRequest');
 
 
 /**


### PR DESCRIPTION
Replaces https://github.com/contao/core-bundle/blob/master/src/Resources/contao/classes/Backend.php#L761-L769 in the core-bundle. The same needs to be implemented for the other bundles obviously.
