### PR TITLE
[RTM] Fix bug with wrong method for feed generation

### DIFF
--- a/src/Resources/contao/dca/tl_news_feed.php
+++ b/src/Resources/contao/dca/tl_news_feed.php
@@ -379,7 +379,7 @@ class tl_news_feed extends Backend
 
 		foreach ($session as $id)
 		{
-			$this->News->generateFeedsByArchive($id);
+			$this->News->generateFeed($id);
 		}
 
 		$this->import('Automator');


### PR DESCRIPTION
If you save a news feed, currently the feed only gets regenerated if the ID of the feed matches the ID of one of the news archives. This should be fixed with this PR.