### PR TITLE
Fix alias generation

### DIFF
--- a/src/Resources/contao/dca/tl_news.php
+++ b/src/Resources/contao/dca/tl_news.php
@@ -628,8 +628,8 @@ class tl_news extends Backend
 			$varValue = StringUtil::generateAlias($dc->activeRecord->headline);
 		}
 
-		$objAlias = $this->Database->prepare("SELECT id FROM tl_news WHERE alias=?")
-								   ->execute($varValue);
+		$objAlias = $this->Database->prepare("SELECT id FROM tl_news WHERE alias=? AND NOT id=?")
+								   ->execute($varValue, $dc->activeRecord->id);
 
 		// Check whether the news alias exists
 		if ($objAlias->numRows > 1 && !$autoAlias)


### PR DESCRIPTION
Under certain circumstances the id is appended to an auto-generated alias, although it would be unique without it. This happens when:
- a news item with the alias field left blank is saved, but the first attempt to save it results in an error
- an existing news item is edited, the alias field is cleared, but the auto-generated alias would be the same as before

How to reproduce this in the online demo:
1. Create a new news item
2. Leave the alias field blank
3. Select no author (or do anything else that will trigger a form error)
4. Save
5. Correct the error
6. Save again
The news item's alias will now contain the id, even though it would have been unique without it.

As far as I can tell this is caused by the generateAlias method which only checks the number of the alias' occurencies. The case where the generated alias already exists, but actually belongs to the item for which it was generated is not handled.

This issue might also apply to other bundles using the same logic (Events comes to mind)