### PR TITLE
"Nachrichten Archivrechte" anstelle von nur "Archivrechte"

### DIFF
--- a/src/Resources/contao/languages/de/tl_user.xlf
+++ b/src/Resources/contao/languages/de/tl_user.xlf
@@ -11,7 +11,7 @@
       </trans-unit>
       <trans-unit id="tl_user.newp.0">
         <source>News permissions</source>
-        <target>Archivrechte</target>
+        <target>Nachrichten Archivrechte</target>
       </trans-unit>
       <trans-unit id="tl_user.newp.1">
         <source>Here you can define the news permissions.</source>

--- a/src/Resources/contao/languages/de/tl_user_group.xlf
+++ b/src/Resources/contao/languages/de/tl_user_group.xlf
@@ -3,7 +3,7 @@
     <body>
       <trans-unit id="tl_user_group.news_legend">
         <source>News permissions</source>
-        <target>Archivrechte</target>
+        <target>Nachrichten Archivrechte</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
Im Backend ist es nicht ganz eindeutig zu was genau "Archivrechte" gehören. 
Deshalb mein Vorschlag daraus ein "Nachrichten Archivrechte" zu machen.