### PR TITLE
add download attribute to download elements

### DIFF
--- a/src/Resources/contao/templates/news/news_full.html5
+++ b/src/Resources/contao/templates/news/news_full.html5
@@ -33,7 +33,7 @@
     <ul class="enclosure">
       <?php foreach ($this->enclosure as $enclosure): ?>
         <li class="download-element ext-<?= $enclosure['extension'] ?>">
-           <a href="<?= $enclosure['href'] ?>" title="<?= $enclosure['title'] ?>"><?= $enclosure['link'] ?> <span class="size">(<?= $enclosure['filesize'] ?>)</span></a>
+           <a href="<?= $enclosure['href'] ?>" title="<?= $enclosure['title'] ?>" download><?= $enclosure['link'] ?> <span class="size">(<?= $enclosure['filesize'] ?>)</span></a>
         </li>
       <?php endforeach; ?>
     </ul>


### PR DESCRIPTION
prevent errors like:
Resource interpreted as Document but transferred with MIME type application/pdf: "*?file=*.pdf". (Chrome) or [Error] Failed to load resource: Das Laden des Frames wurde unterbrochen (*, line 0) *?file=*.pdf (Safari)
see more https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download