### PR TITLE
reduce memory consumption during sitemap generation

### DIFF
--- a/src/Resources/contao/dca/tl_news.php
+++ b/src/Resources/contao/dca/tl_news.php
@@ -157,7 +157,7 @@ $GLOBALS['TL_DCA']['tl_news'] = array
 		(
 			'foreignKey'              => 'tl_news_archive.title',
 			'sql'                     => "int(10) unsigned NOT NULL default '0'",
-			'relation'                => array('type'=>'belongsTo', 'load'=>'eager')
+			'relation'                => array('type'=>'belongsTo', 'load'=>'lazy')
 		),
 		'tstamp' => array
 		(
@@ -200,7 +200,7 @@ $GLOBALS['TL_DCA']['tl_news'] = array
 			'foreignKey'              => 'tl_user.name',
 			'eval'                    => array('doNotCopy'=>true, 'chosen'=>true, 'mandatory'=>true, 'includeBlankOption'=>true, 'tl_class'=>'w50'),
 			'sql'                     => "int(10) unsigned NOT NULL default '0'",
-			'relation'                => array('type'=>'hasOne', 'load'=>'eager')
+			'relation'                => array('type'=>'hasOne', 'load'=>'lazy')
 		),
 		'date' => array
 		(


### PR DESCRIPTION
See contao/core-bundle#1157

The issue is the following:

* During sitemap generation, _all_ news articles of one archive are loaded at once via `Model`s.
* Changing this to pure database queries requires more work or code duplication, since the functions to generate the news or event URL need a `Model`.
* Due to `'load'=>'eager'` on the `author` and `pid` of `tl_news` and `tl_calendar_events` this results in a large memory consumption, since the author and archive/calendar is duplicated in memory for each news entry.
* Since the advantages of eagerly loading these related objects are negligible and the disadvantages are potentially huge with growing numbers of news entries, the easiest solution is to just set these relations to `lazy`.
* Then, in the worst case, if you display 100 news entries in your newslist module for example and each of these news entries have a _different_ author you would have 100 additional queries (assuming those authors haven't been loaded elsewhere before). If you only have 5 different authors in total, there would be only 5 addition queries (due to the Model registry).

Comparison: when using 10.000 news entries the peak memory usage would be around 1.4 GiB when loading them all. After these changes the peak memory usage is only around 60 MiB.