### PR TITLE
Fix broken permission check in cut action

### DIFF
--- a/src/Resources/contao/dca/tl_news.php
+++ b/src/Resources/contao/dca/tl_news.php
@@ -537,8 +537,8 @@ class tl_news extends Backend
 				break;
 
 			case 'cut':
-				if (Input::get('mode') == 1)
-				{
+			case 'copy':
+				if (Input::get('act') == 'cut' && Input::get('mode') == 1) {
 					$objArchive = $this->Database->prepare("SELECT pid FROM tl_news WHERE id=?")
 						->limit(1)
 						->execute(Input::get('pid'));
@@ -548,17 +548,16 @@ class tl_news extends Backend
 						throw new Contao\CoreBundle\Exception\AccessDeniedException('Invalid news item ID ' . Input::get('pid') . '.');
 					}
 
-					if (!\in_array($objArchive->pid, $root))
-					{
-						throw new Contao\CoreBundle\Exception\AccessDeniedException('Not enough permissions to ' . Input::get('act') . ' news item ID ' . $id . ' of news archive ID ' . $objArchive->pid . '.');
-					}
-
-					break;
+					$pid = $objArchive->pid;
 				}
-			case 'copy':
-				if (!\in_array(Input::get('pid'), $root))
+				else
 				{
-					throw new Contao\CoreBundle\Exception\AccessDeniedException('Not enough permissions to ' . Input::get('act') . ' news item ID ' . $id . ' to news archive ID ' . Input::get('pid') . '.');
+					$pid = Input::get('pid');
+				}
+
+				if (!\in_array($pid, $root))
+				{
+					throw new Contao\CoreBundle\Exception\AccessDeniedException('Not enough permissions to ' . Input::get('act') . ' news item ID ' . $id . ' to news archive ID ' . $pid . '.');
 				}
 				// NO BREAK STATEMENT HERE
 

--- a/src/Resources/contao/dca/tl_news.php
+++ b/src/Resources/contao/dca/tl_news.php
@@ -538,10 +538,11 @@ class tl_news extends Backend
 
 			case 'cut':
 			case 'copy':
-				if (Input::get('act') == 'cut' && Input::get('mode') == 1) {
+				if (Input::get('act') == 'cut' && Input::get('mode') == 1)
+				{
 					$objArchive = $this->Database->prepare("SELECT pid FROM tl_news WHERE id=?")
-						->limit(1)
-						->execute(Input::get('pid'));
+												 ->limit(1)
+												 ->execute(Input::get('pid'));
 
 					if ($objArchive->numRows < 1)
 					{

--- a/src/Resources/contao/dca/tl_news.php
+++ b/src/Resources/contao/dca/tl_news.php
@@ -537,6 +537,24 @@ class tl_news extends Backend
 				break;
 
 			case 'cut':
+				if (Input::get('mode') == 1)
+				{
+					$objArchive = $this->Database->prepare("SELECT pid FROM tl_news WHERE id=?")
+						->limit(1)
+						->execute(Input::get('pid'));
+
+					if ($objArchive->numRows < 1)
+					{
+						throw new Contao\CoreBundle\Exception\AccessDeniedException('Invalid news item ID ' . Input::get('pid') . '.');
+					}
+
+					if (!\in_array($objArchive->pid, $root))
+					{
+						throw new Contao\CoreBundle\Exception\AccessDeniedException('Not enough permissions to ' . Input::get('act') . ' news item ID ' . $id . ' of news archive ID ' . $objArchive->pid . '.');
+					}
+
+					break;
+				}
 			case 'copy':
 				if (!\in_array(Input::get('pid'), $root))
 				{


### PR DESCRIPTION
When enabling custom sorting for news (customer uses example explained here http://help.rocksolidthemes.com/discussions/contao/16551-verwendung-reihenfolge-der-portfolio-eintrge#comment_40419059) the permission check fails for regular users if they try to move a new item.

This is caused because the pid refers to the news id of the related news item when moving. This PR fixes the issue.

Issue occurs in 4.4 and 4.5.