### PR TITLE
allow newsreader selection in newslist

### DIFF
--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -9,7 +9,7 @@
  */
 
 // Add palettes to tl_module
-$GLOBALS['TL_DCA']['tl_module']['palettes']['newslist']    = '{title_legend},name,headline,type;{config_legend},news_archives,numberOfItems,news_featured,news_order,skipFirst,perPage;{template_legend:hide},news_metaFields,news_template,customTpl;{image_legend:hide},imgSize;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID';
+$GLOBALS['TL_DCA']['tl_module']['palettes']['newslist']    = '{title_legend},name,headline,type;{config_legend},news_archives,news_readerModule,numberOfItems,news_featured,news_order,skipFirst,perPage;{template_legend:hide},news_metaFields,news_template,customTpl;{image_legend:hide},imgSize;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID';
 $GLOBALS['TL_DCA']['tl_module']['palettes']['newsreader']  = '{title_legend},name,headline,type;{config_legend},news_archives;{template_legend:hide},news_metaFields,news_template,customTpl;{image_legend:hide},imgSize;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID';
 $GLOBALS['TL_DCA']['tl_module']['palettes']['newsarchive'] = '{title_legend},name,headline,type;{config_legend},news_archives,news_readerModule,news_format,news_order,news_jumpToCurrent,perPage;{template_legend:hide},news_metaFields,news_template,customTpl;{image_legend:hide},imgSize;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID';
 $GLOBALS['TL_DCA']['tl_module']['palettes']['newsmenu']    = '{title_legend},name,headline,type;{config_legend},news_archives,news_showQuantity,news_format,news_startDay,news_order;{redirect_legend},jumpTo;{template_legend:hide},customTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID';

--- a/src/Resources/contao/modules/ModuleNewsList.php
+++ b/src/Resources/contao/modules/ModuleNewsList.php
@@ -60,6 +60,12 @@ class ModuleNewsList extends ModuleNews
 			return '';
 		}
 
+		// Show the news reader if an item has been selected
+		if ($this->news_readerModule > 0 && (isset($_GET['items']) || (\Config::get('useAutoItem') && isset($_GET['auto_item']))))
+		{
+			return $this->getFrontendModule($this->news_readerModule, $this->strColumn);
+		}
+
 		return parent::generate();
 	}
 


### PR DESCRIPTION
Imho there is no _real_ reason [1] not to allow the selection of a newsreader also in the newslist - not just the newsarchive (or the eventlist for that matter).

This would allow the following URL structure:
```php
example.org/news            // the news list page
example.org/news/news-entry // news detail page
```
without having to resort to other means, like using the [newslist_extended](https://github.com/fritzmg/contao-newslist-extended) extension or the old urlcleaner extension, or including either the newslist or newsreader module in your own template, depending on whether there is an `auto_item` parameter present.

[1] one "reason" not to do it would be because people get often confused about this feature. They sometimes mistakenly select an eventreader in their eventlist module for example, which they then display somewhere in the page _layout_, causing problems on the newsreader page